### PR TITLE
Delete local.properties

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Sep 01 12:27:33 CST 2020
-sdk.dir=/Users/ken/Library/Android/sdk


### PR DESCRIPTION
In GitLab by @wesely.ong on Nov 5, 2020, 11:24

`local.properties` should not be added into repo