### PR TITLE
Modify the pre commit hook's header and remove useless command

### DIFF
--- a/script/pre_commit_format.sh
+++ b/script/pre_commit_format.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
 mkdir .git/hooks/
-echo "#!/bin/sh
+echo "#!/usr/bin/env sh
 #
 # An example hook script to verify what is about to be committed.
 # Called by \"git commit\" with no arguments.  The hook should
@@ -8,7 +8,6 @@ echo "#!/bin/sh
 # it wants to stop the commit.
 #
 # To enable this hook, rename this file to \"pre-commit\".
-source ~/.bash_profile
 ./gradlew formatCheck
 result=\$?
 SLASH='"\\"'


### PR DESCRIPTION
### Summary
1. Remove the command `source ~/.bash_profile` because it may not exist in some
environment and it seems useless in this situation.
2. Change `#!/bin/sh` to `#!/usr/bin/env sh` for better flexibility