### PR TITLE
Remove the findViewById that try to find the non exist view in HotArticleListAdapter

### DIFF
--- a/app/src/main/java/tw/y_studio/ptt/adapter/HotArticleListAdapter.kt
+++ b/app/src/main/java/tw/y_studio/ptt/adapter/HotArticleListAdapter.kt
@@ -257,7 +257,6 @@ class HotArticleListAdapter(private val context: Context, private val data: List
         val textViewDate: TextView = v.findViewById(R.id.article_list_item_textView_date)
         val like: AppCompatImageButton = v.findViewById(R.id.article_list_item_imageButton_like)
         val dislike: AppCompatImageButton = v.findViewById(R.id.article_list_item_imageButton_dislike)
-        val more: AppCompatImageButton = v.findViewById(R.id.article_list_item_imageButton_more)
         val image: SimpleDraweeView = v.findViewById(R.id.article_list_item_picture)
     }
 


### PR DESCRIPTION
### Summary
There isn't any id in the `hot_article_list_item.xml` that match id `article_list_item_imageButton_more` , so I remove it to fix the crash.